### PR TITLE
Optimization: Cache the sha of valid sources to avoid costly evals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 var aparse = require('acorn').parse;
 function parse (src) { return aparse(src, { ecmaVersion: 6 }) }
 
+var shasum = require('shasum');
+var valid = {};
+
 module.exports = function (src, file) {
+    var h = shasum(src);
+    if (typeof valid[h] !== 'undefined') return;
+    
     if (typeof src !== 'string') src = String(src);
     
     try {
@@ -9,7 +15,10 @@ module.exports = function (src, file) {
         return;
     }
     catch (err) {
-        if (err === 'STOP') return undefined;
+        if (err === 'STOP') {
+            valid[h] = true;
+            return;
+        }
         if (err.constructor.name !== 'SyntaxError') throw err;
         return errorInfo(src, file);
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "detect and report syntax errors in source code strings",
   "main": "index.js",
   "dependencies": {
-    "acorn": "^1.0.3"
+    "acorn": "^1.0.3",
+    "shasum": "^1.0.1"
   },
   "devDependencies": {
     "tape": "~2.4.1"

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,38 @@
+var test = require('tape');
+
+var fs = require('fs');
+var check = require('../');
+
+test('cache - ok', function (t) {
+    var file = __dirname + '/sources/ok.js';
+    var src = fs.readFileSync(file);
+
+    var err = check(src, file);
+    t.notOk(err);
+
+    err = check(src, file);
+    t.notOk(err);
+
+    t.end();
+});
+
+test('cache - error', function (t) {
+    var file = __dirname + '/sources/check.js';
+    var src = fs.readFileSync(file);
+
+    var err = check(src, file);
+    t.ok(err);
+    t.equal(err.line, 5);
+    t.equal(err.column, 30);
+    t.equal(err.message, 'Unexpected token');
+    t.ok(String(err).indexOf(file + ':5'));
+
+    err = check(src, file);
+    t.ok(err);
+    t.equal(err.line, 5);
+    t.equal(err.column, 30);
+    t.equal(err.message, 'Unexpected token');
+    t.ok(String(err).indexOf(file + ':5'));
+
+    t.end();
+});


### PR DESCRIPTION
Maybe the cache should happen inside browserify? It makes sense here too though. I saw my watchify rebuilds drop by ~50-80ms :smile: I'd like your blessing on this @substack 