### PR TITLE
Add `sourceType` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var aparse = require('acorn').parse;
 function parse (src, opts) {
     if (!opts) opts = {}
     return aparse(src, {
+        sourceType: opts.sourceType || 'string',
         ecmaVersion: opts.ecmaVersion || 8,
         allowHashBang: true
     });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var aparse = require('acorn').parse;
 function parse (src, opts) {
     if (!opts) opts = {}
     return aparse(src, {
-        sourceType: opts.sourceType || 'string',
+        sourceType: opts.sourceType || 'script',
         ecmaVersion: opts.ecmaVersion || 8,
         allowHashBang: true
     });

--- a/readme.markdown
+++ b/readme.markdown
@@ -58,6 +58,7 @@ If there are no syntax errors in `src`, return `undefined`.
 Optionally set:
 
 * `opts.ecmaVersion` - default: 8
+* `opts.sourceType` - default: 'script'
 
 ## err.toString()
 

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,23 @@
+var test = require('tap').test;
+
+var fs = require('fs');
+var check = require('../');
+
+var file = __dirname + '/sources/esm.js';
+var src = fs.readFileSync(file);
+
+test('esm with sourceType script', function (t) {
+    var err = check(src, file);
+    t.ok(err);
+    t.equal(err.line, 1);
+    t.equal(err.column, 1);
+    t.equal(err.message, "'import' and 'export' may appear only with 'sourceType: module'");
+    t.ok(String(err).indexOf(file + ':1'));
+    t.end();
+});
+
+test('esm with sourceType module', function (t) {
+    var err = check(src, file, { sourceType: 'module' });
+    t.notOk(err);
+    t.end();
+});

--- a/test/sources/esm.js
+++ b/test/sources/esm.js
@@ -1,0 +1,2 @@
+import x from 'y';
+export default z;


### PR DESCRIPTION
Allows using `syntaxError` on ES modules source files.